### PR TITLE
Keep front page hero rotating on hover

### DIFF
--- a/web/src/components/RotatingHero.astro
+++ b/web/src/components/RotatingHero.astro
@@ -268,8 +268,9 @@ const panes: Pane[] = [
             }),
         );
 
-        hero.addEventListener('mouseenter', pause);
-        hero.addEventListener('mouseleave', resume);
+        // Keep pointer hover non-blocking so the landing page continues to
+        // rotate while someone reads or inspects the hero. Keyboard focus still
+        // pauses because rotating focused controls would be disorienting.
         hero.addEventListener('focusin', pause);
         hero.addEventListener('focusout', resume);
         document.addEventListener('visibilitychange', () => (document.hidden ? pause() : resume()));


### PR DESCRIPTION
## Summary
- Removes pointer-hover pause from the front-page hero carousel so it keeps auto-rotating while someone reads or inspects the banner.
- Keeps keyboard focus pause, visibility pause, reduced-motion handling, and manual selector behavior intact.

## Validation
- Reproduced current deployed/local behavior: auto-rotation works unless hover pause is triggered.
- Verified locally after the fix: simulated mouseenter leaves paused=false and the title advances from Event Sourcing to CQRS after the interval.
- npm run check: 0 errors, 0 broken local links.