### PR TITLE
Make Storybook page full-page with nav and controls visible

### DIFF
--- a/web/src/components/StorybookEmbed.astro
+++ b/web/src/components/StorybookEmbed.astro
@@ -172,4 +172,10 @@ const src = buildStorybookSrc(storybookRoot, initialStoryPath, showNav);
     padding: 0;
     max-width: none;
   }
+
+  /* Hide page title (h1#_top) and any description paragraph for full-page Storybook */
+  :has(.storybook-embed[data-full-page="true"]) h1#_top,
+  :has(.storybook-embed[data-full-page="true"]) h1#_top + p {
+    display: none;
+  }
 </style>


### PR DESCRIPTION
## Changed
- Storybook documentation page now fills the entire viewport with Storybook's own story navigation and controls panel visible — no doc-site chrome above it