### PR TITLE
Pass tableOfContents frontmatter key through content sync

### DIFF
--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -350,6 +350,7 @@ async function convertFile(raw, ctx) {
     const fm = { title };
     if (src.description) fm.description = src.description;
     if (src.sidebar) fm.sidebar = src.sidebar; // order/label/badge, when authors set it
+    if (src.tableOfContents !== undefined) fm.tableOfContents = src.tableOfContents;
     const fmYaml = yaml.dump(fm, { lineWidth: -1 }).trimEnd();
     return `---\n${fmYaml}\n---\n\n` + out.replace(/\s*$/, '') + '\n';
 }


### PR DESCRIPTION
## Changed
- The content sync script now preserves the `tableOfContents` frontmatter key from product repo docs pages, allowing pages to opt out of Starlight's right-hand table of contents panel (used by full-page Storybook embeds).