### PR TITLE
Add Workbench to Chronicle nav

### DIFF
--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -53,7 +53,7 @@ const PRODUCTS = [
             },
             {
                 label: 'Running Chronicle',
-                sections: ['Hosting', 'Configuration', 'Connection Strings', 'Testing', 'Troubleshooting'],
+                sections: ['Workbench', 'Hosting', 'Configuration', 'Connection Strings', 'Testing', 'Troubleshooting'],
             },
             {
                 label: 'Reference',


### PR DESCRIPTION
## Added
- Workbench section wired into the Chronicle **Running Chronicle** sidebar bucket in the docs site.