### PR TITLE
Promote Workbench to top-level nav bucket

### DIFF
--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -53,8 +53,9 @@ const PRODUCTS = [
             },
             {
                 label: 'Running Chronicle',
-                sections: ['Workbench', 'Hosting', 'Configuration', 'Connection Strings', 'Testing', 'Troubleshooting'],
+                sections: ['Hosting', 'Configuration', 'Connection Strings', 'Testing', 'Troubleshooting'],
             },
+            { label: 'Workbench', sections: ['Workbench'] },
             {
                 label: 'Reference',
                 sections: ['Code Analysis', 'Statistics', 'Contributing'],


### PR DESCRIPTION
## Changed
- Workbench moved from the **Running Chronicle** sidebar bucket to its own top-level bucket, at the same level as Running Chronicle and Reference.