### PR TITLE
Update Cratis Stack navigation and add Architecture submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "CLI"]
 	path = CLI
 	url = https://github.com/cratis/cli
+[submodule "Architecture"]
+	path = Architecture
+	url = https://github.com/Cratis/Architecture

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -41,6 +41,7 @@ const overviewTopic = {
             collapsed: true,
             items: [
                 { label: 'Overview', slug: 'scenarios' },
+                { label: 'Build a full-stack feature', slug: 'build-a-full-app' },
                 {
                     label: 'Camel Casing',
                     collapsed: true,
@@ -74,6 +75,7 @@ const overviewTopic = {
         },
         {
             label: 'Adopt and trust',
+            collapsed: true,
             items: [
                 { label: 'Learning paths', slug: 'learning-paths' },
                 { label: 'FAQ', slug: 'faq' },
@@ -89,6 +91,7 @@ const overviewTopic = {
         },
         {
             label: 'AI',
+            collapsed: true,
             items: [
                 { label: 'AI-native development', slug: 'ai-native-development' },
                 { label: 'Plugins', slug: 'plugins' },
@@ -99,6 +102,7 @@ const overviewTopic = {
         { label: 'Event Modeling', slug: 'event-modeling' },
         {
             label: 'Testing',
+            collapsed: true,
             items: [
                 { label: 'Testing with Cratis', slug: 'testing-with-cratis' },
                 { label: 'Specifications', slug: 'specifications' },
@@ -106,6 +110,7 @@ const overviewTopic = {
         },
         {
             label: 'Tools',
+            collapsed: true,
             items: [
                 { label: 'VS Code extension', slug: 'tools/vscode-extension' },
                 { label: 'Lens', slug: 'tools/lens' },
@@ -114,6 +119,7 @@ const overviewTopic = {
         { label: 'Auth and compliance', slug: 'auth-and-compliance' },
         {
             label: 'AuthProxy',
+            collapsed: true,
             items: [
                 { label: 'Overview', slug: 'authproxy' },
                 { label: 'Get started', slug: 'authproxy/get-started' },
@@ -123,7 +129,6 @@ const overviewTopic = {
                 { label: 'Invites and lobby', slug: 'authproxy/invites-and-lobby' },
             ],
         },
-        { label: 'Build a full-stack feature', slug: 'build-a-full-app' },
         { label: 'Samples', slug: 'samples' },
         { label: 'Showcase and architectures', slug: 'showcase' },
         { label: "What's new", slug: 'whats-new' },
@@ -233,6 +238,7 @@ export default defineConfig({
                         cli: ['/cli', '/cli/**'],
                         fundamentals: ['/fundamentals', '/fundamentals/**'],
                         contributing: ['/contributing', '/contributing/**'],
+                        architecture: ['/architecture', '/architecture/**'],
                     },
                 }),
                 // Per-page action row: Copy Markdown + Open in AI assistant + Share.

--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -123,6 +123,16 @@ const PRODUCTS = [
             path.join(reposRoot, '.github'),
             path.join(docRepoRoot, 'GitHubLanding')),
     },
+    {
+        // Roslyn analyzers enforcing Cratis architectural conventions across all products.
+        key: 'architecture', label: 'Architecture', icon: 'seti:config', sidebarMode: 'toc',
+        src: firstExisting(
+            path.join(reposRoot, 'Architecture', 'Documentation'),
+            path.join(docRepoRoot, 'Architecture', 'Documentation')),
+        buckets: [
+            { label: 'Code Analysis', sections: ['Code Analysis'] },
+        ],
+    },
 ];
 
 const ASSET_EXT = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif', '.html', '.js', '.css', '.json']);

--- a/web/src/components/RotatingHero.astro
+++ b/web/src/components/RotatingHero.astro
@@ -76,6 +76,18 @@ const panes: Pane[] = [
             community,
         ],
     },
+    {
+        label: 'Cratis Stack',
+        title: 'Chronicle, Arc, Components, and the tools — working as one',
+        tagline:
+            'The Cratis Stack assembles into a cohesive whole: Chronicle owns the event log and read models, Arc carries a command through generated proxies to a live React screen, Components keeps the UI consistent, and Studio, the CLI, and Workbench complete the picture — all sharing identity, tenancy, and conventions so every piece reinforces the others.',
+        actions: [
+            getStarted,
+            { text: 'Explore the stack', link: '/cratis-stack/', variant: 'minimal', icon: 'open-book' },
+            gitHub,
+            community,
+        ],
+    },
 ];
 ---
 

--- a/web/src/content/docs/code-analysis.mdx
+++ b/web/src/content/docs/code-analysis.mdx
@@ -33,34 +33,10 @@ Each analyzer ships *inside* the package it validates — there's nothing extra 
   <SimpleCard title="Arc + Chronicle — ARCCHR####" icon="seti:db" link="/arc/backend/chronicle/code-analysis/">
     Aggregate-root event-handler rules for Arc-on-Chronicle. Ships with the Chronicle integration.
   </SimpleCard>
+  <SimpleCard title="Architecture — ARCH####" icon="seti:config" link="/architecture/code-analysis/">
+    Rules for architectural boundaries and dependency flow. Ships with the <code>Cratis.Architecture</code> package.
+  </SimpleCard>
 </CardGrid>
-
-### Chronicle event-sourcing rules (`CHR####`)
-
-The [Chronicle analyzer](/chronicle/code-analysis/) enforces the event-sourcing shapes — events, projections, reducers, reactors, and constraints. A representative slice:
-
-| Rule | Catches |
-|---|---|
-| `CHR0001` | A type appended to an event sequence that's missing `[EventType]` *(quick fix adds it)* |
-| `CHR0004` / `CHR0006` | A reactor / reducer method whose signature doesn't match an allowed shape |
-| `CHR0015` / `CHR0017` | A projection or constraint with side effects (injecting `ICommandPipeline` / `IEventLog`) |
-| `CHR0016` / `CHR0018` | Imperative code inside a `Define()` that should only contain builder calls |
-| `CHR0021` | An event type that isn't a `record` (immutability) |
-
-The error-level `[EventType]` rules (`CHR0001`, `CHR0002`, `CHR0003`, `CHR0005`, `CHR0007`) come with an automatic code fix. See the [full CHR catalog](/chronicle/code-analysis/) for all 21 rules.
-
-### Arc command & read-model rules (`ARC####`)
-
-The [Arc.Core analyzer](/arc/backend/code-analysis/) validates the model-bound CQRS shapes — the ones the [writing-correct-examples](/plugins/) discipline keeps reiterating, now checked by the compiler:
-
-| Rule | Catches |
-|---|---|
-| `ARC0001` | A `[ReadModel]` query method that doesn't return the read model (or an allowed wrapper) |
-| `ARC0002` | A command-like type missing its `[Command]` attribute |
-| `ARC0003` | A `Handle()` method declared somewhere other than the command type itself |
-| `ARC0004` | A `[Command]` type with no public `Handle()` method |
-
-And for Arc on Chronicle, [`ARCCHR0001`](/arc/backend/chronicle/code-analysis/) checks aggregate-root event-handler `On` signatures.
 
 ## ESLint packages
 


### PR DESCRIPTION
## Added

- Cratis Stack pane to the landing page hero carousel, covering Chronicle, Arc, Components, Studio, CLI, and Workbench
- Architecture (`CRARCH####`) card on the Code Analysis page, linking to the synced rule catalog
- Architecture submodule (`https://github.com/Cratis/Architecture`) wired into the docs site sync pipeline

## Changed

- Adopt and trust, AI, Testing, Tools, and AuthProxy sidebar sections now collapse by default
- Build a full-stack feature moved into the Scenarios group in the Cratis Stack sidebar
- Inline CHR/ARC rule summary tables removed from the Code Analysis page — the linked catalogs are the canonical reference