### PR TITLE
Drop the clients property from ChronicleClientTabs

### DIFF
--- a/.ai/skills/chronicle-client-docs/SKILL.md
+++ b/.ai/skills/chronicle-client-docs/SKILL.md
@@ -72,11 +72,7 @@ If a shared page still has direct C# fences, treat it as migration debt. Do not 
 5. Prefer `.md` for snippet files. Use `.mdx` only if the snippet file itself needs MDX syntax.
 6. Keep the snippet ID extensionless in the shared page. The sync supports both `.md` and `.mdx`.
 
-Use `clients="csharp,elixir"` only when a concept genuinely exists for only some clients:
-
-```mdx
-<ChronicleClientTabs snippet="events/appending/occurred" clients="csharp,elixir" />
-```
+`<ChronicleClientTabs />` has no `clients` property. Never add one, and never edit the sync/audit scripts to reintroduce one. The shared page does not declare which clients apply to an example — the sync discovers that by checking every registered client's snippet root for a file at that id, and renders a tab only for the clients where one exists. When a concept genuinely exists for only some clients, just don't add a snippet file for the others.
 
 Prefer keeping every generally supported client visible in shared pages. If a shared workflow is not implemented for one client yet, add a real snippet file for that client that says the feature is not supported yet instead of omitting the tab. This keeps the docs honest and makes the gap visible:
 

--- a/web/chronicle-client-docs.yml
+++ b/web/chronicle-client-docs.yml
@@ -84,7 +84,6 @@ clients:
 
   kotlin:
     label: Kotlin
-    includeByDefault: true
     snippets:
       paths:
         - ../../Chronicle.Kotlin/Documentation/client-snippets
@@ -108,7 +107,6 @@ clients:
 
   java:
     label: Java
-    includeByDefault: false
     snippets:
       paths:
         - ../../Chronicle.Kotlin/Documentation/client-snippets-java
@@ -126,7 +124,6 @@ clients:
 
   elixir:
     label: Elixir
-    includeByDefault: true
     snippets:
       paths:
         - ../../Chronicle.Elixir/Documentation/client-snippets
@@ -150,7 +147,6 @@ clients:
 
   typescript:
     label: TypeScript
-    includeByDefault: true
     snippets:
       paths:
         - ../../Chronicle.TypeScript/Documentation/client-snippets

--- a/web/scripts/audit-chronicle-client-docs.mjs
+++ b/web/scripts/audit-chronicle-client-docs.mjs
@@ -15,11 +15,9 @@ const chronicleDocsRoot = chronicleClientDocsConfig.sharedDocsRoot;
 const clients = chronicleClientDocsConfig.clients.map((client) => ({
     key: client.key,
     label: client.label,
-    includeByDefault: client.includeByDefault,
     snippetRoot: client.snippetRoot,
     docsRoot: client.publicDocs?.root,
 }));
-const defaultClients = clients.filter((client) => client.includeByDefault);
 
 const args = new Set(process.argv.slice(2));
 const valueArg = (name) => {
@@ -165,22 +163,17 @@ async function collectAudit() {
                 continue;
             }
 
-            const requested = (getAttr(attrs, 'clients') ?? defaultClients.map((client) => client.key).join(','))
-                .split(',')
-                .map((client) => client.trim().toLowerCase())
-                .filter(Boolean);
-
-            placeholders.push({ file: rel, snippet, clients: requested });
-
-            for (const key of requested) {
-                const client = clients.find((candidate) => candidate.key === key);
-                if (!client) {
-                    missingSnippets.push(`${rel}: unknown Chronicle client "${key}" for snippet "${snippet}"`);
-                    continue;
+            const available = [];
+            for (const client of clients) {
+                if (await snippetExists(client, snippet)) {
+                    available.push(client.key);
                 }
-                if (!(await snippetExists(client, snippet))) {
-                    missingSnippets.push(`${rel}: missing ${client.label} snippet "${snippet}" in ${client.snippetRoot}`);
-                }
+            }
+
+            placeholders.push({ file: rel, snippet, clients: available });
+
+            if (!available.length) {
+                missingSnippets.push(`${rel}: no client has a snippet for "${snippet}"`);
             }
         }
     }

--- a/web/scripts/chronicle-client-docs-config.mjs
+++ b/web/scripts/chronicle-client-docs-config.mjs
@@ -92,7 +92,6 @@ export async function loadChronicleClientDocsConfig() {
         return {
             key,
             label: client.label ?? key,
-            includeByDefault: client.includeByDefault !== false,
             snippetRoot: firstExistingPath(snippets.paths, `clients.${key}.snippets.paths`),
             legacySnippetBaseline: Number(snippets.legacyBaseline ?? 0),
             publicDocs: publicDocs
@@ -117,13 +116,6 @@ export async function loadChronicleClientDocsConfig() {
             label: client.label,
             src: client.snippetRoot,
         })),
-        defaultSnippetClients: clients
-            .filter((client) => client.includeByDefault)
-            .map((client) => ({
-                key: client.key,
-                label: client.label,
-                src: client.snippetRoot,
-            })),
         publicDocsClients: clients
             .filter((client) => client.publicDocs)
             .map((client) => ({

--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -137,7 +137,6 @@ const PRODUCTS = [
 ];
 
 const CHRONICLE_CLIENT_SNIPPETS = chronicleClientDocsConfig.snippetClients;
-const DEFAULT_CHRONICLE_CLIENT_SNIPPETS = chronicleClientDocsConfig.defaultSnippetClients;
 const CHRONICLE_CLIENT_DOCS = chronicleClientDocsConfig.publicDocsClients;
 const CHRONICLE_SHARED_TOPICS = chronicleClientDocsConfig.sharedTopics;
 
@@ -362,6 +361,9 @@ async function fileExists(filePath) {
     }
 }
 
+// Returns null when the client repo has no snippet for this id — that just
+// means the tab is omitted, not an error. Chronicle shared docs don't track
+// which clients apply to a given example; that's discovered from disk.
 async function readClientSnippet(source, snippet) {
     for (const ext of ['.mdx', '.md']) {
         const candidate = path.join(source.src, snippet + ext);
@@ -371,9 +373,7 @@ async function readClientSnippet(source, snippet) {
             return body.trim();
         }
     }
-    throw new Error(
-        `[sync] Missing Chronicle ${source.label} client snippet "${snippet}" in ${source.src}`
-    );
+    return null;
 }
 
 function isInsideFencedCode(body, index) {
@@ -424,19 +424,18 @@ async function expandChronicleClientTabs(body, ctx) {
         }
 
         const syncKey = getAttr(attrs, 'syncKey') ?? 'chronicle-client';
-        const clientsAttr = getAttr(attrs, 'clients');
-        const requested = clientsAttr
-            ? clientsAttr.split(',').map((client) => client.trim().toLowerCase()).filter(Boolean)
-            : DEFAULT_CHRONICLE_CLIENT_SNIPPETS.map((source) => source.key);
 
         const tabs = [];
-        for (const key of requested) {
-            const source = CHRONICLE_CLIENT_SNIPPETS.find((candidate) => candidate.key === key);
-            if (!source) {
-                throw new Error(`[sync] Unknown Chronicle client snippet key "${key}" in ${ctx.srcPath}`);
-            }
+        for (const source of CHRONICLE_CLIENT_SNIPPETS) {
             const content = await readClientSnippet(source, snippet);
+            if (content === null) continue;
             tabs.push({ source, content });
+        }
+
+        if (!tabs.length) {
+            throw new Error(
+                `[sync] ChronicleClientTabs snippet "${snippet}" in ${ctx.srcPath} has no matching snippet in any client repo`
+            );
         }
 
         const expanded = [


### PR DESCRIPTION
# Summary

`<ChronicleClientTabs />` no longer needs a `clients` attribute to say which clients apply to an example. Chronicle's shared docs shouldn't have to know that — the sync now discovers it by checking each client repo's snippet root for a matching file and rendering a tab only where one exists.

## Changed

- `<ChronicleClientTabs snippet="..." />` auto-discovers which clients have a snippet instead of reading a `clients="..."` attribute; a client with no matching snippet is simply omitted from the tab group instead of requiring an explicit list or failing the build.
- Removed `includeByDefault` from `web/chronicle-client-docs.yml` — there is no more "default client set" to opt a client in or out of.

## Removed

- The `clients` attribute on `<ChronicleClientTabs />` is no longer read. A placeholder still fails the build if *no* client has a matching snippet at all.