### PR TITLE
Upgrade TypeScript to 7

### DIFF
--- a/Source/package.json
+++ b/Source/package.json
@@ -73,7 +73,7 @@
         "ts-node": "10.9.2",
         "typedoc": "^0.27.5",
         "typedoc-plugin-markdown": "4.3.3",
-        "typescript": "5.7.2"
+        "typescript": "7.0.2"
     },
     "packageManager": "yarn@4.5.3"
 }


### PR DESCRIPTION
## Summary

Bumps the only concrete `typescript` dependency in the Documentation repo to the TypeScript 7 native (Go) compiler.

## Packages changed (1)

| File | Package | Old | New |
|---|---|---|---|
| `Source/package.json` (devDependencies) | `typescript` | `5.7.2` | `7.0.2` |

No other `package.json` in the repo declares a concrete `typescript` dependency. `web/package.json` (the Astro site built in CI) and `Source/docs/Documentation/test-storybook/package.json` do **not** declare `typescript` directly, so they were left untouched. `@types/*` and other packages were not modified. No `typescript` peer-dependency lower-bound ranges exist to preserve.

## Package manager

`Source` is a Yarn 4.5.3 (Corepack) project. Lockfiles are git-ignored in this repo (`yarn.lock`, `package-lock.json`), so this PR contains only the `package.json` change — no lockfile diff.

## Verification result — blocker

TypeScript 7.0.2 works as a **CLI drop-in** (`tsc --version` → `Version 7.0.2`), but the published `typescript@7.0.2` native package **no longer ships the compiler library API** — it contains only `lib/tsc.js` plus a native-binary launcher and per-platform optional-dependency binaries. `require('typescript').createProgram` is `undefined`.

Consequences for the `Source` project:

- **`yarn install` fails** — Yarn 4's builtin `compat/typescript` patch expects the TS 5.x file layout (`lib/_tsc.js`) and errors with `ENOENT ... lib/_tsc.js` on the new package shape.
- **`yarn build` / `build:ts` would fail** — `Source` drives its build through `typedoc`, `typedoc-plugin-markdown`, and `ts-node/esm`, all of which consume the TypeScript compiler API as a library; that API is absent in TS7. `typedoc` also peer-requires `~5.x` and reports the mismatch.

These are fundamental to the TS7 native package (CLI-only), not fixable by a config tweak, so the version bump is kept and flagged for human review.

## CI impact

None expected. The `docs-site.yml` workflow builds `Documentation/web` (Astro), which does **not** declare `typescript` and resolves it transitively (`~5.x` via `typedoc`). The `Source` project is not built in CI, so CI should remain green despite the `Source` toolchain incompatibility above.

## Workflow changes

None. No workflow under `.github/workflows/` pins a `typescript` version or installs `tsc` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)