### PR TITLE
Add Screenplay and Prompter to the docs site

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -131,6 +131,22 @@ jobs:
           token: ${{ secrets.DOCS_CHECKOUT_TOKEN || github.token }}
           path: Architecture
 
+      - name: Checkout Screenplay
+        uses: actions/checkout@v4
+        with:
+          repository: Cratis/Screenplay
+          ref: main
+          token: ${{ secrets.DOCS_CHECKOUT_TOKEN || github.token }}
+          path: Screenplay
+
+      - name: Checkout Prompter
+        uses: actions/checkout@v4
+        with:
+          repository: Cratis/Prompter
+          ref: main
+          token: ${{ secrets.DOCS_CHECKOUT_TOKEN || github.token }}
+          path: Prompter
+
       - uses: actions/setup-node@v4
         with:
           node-version: 23   # Components (Storybook build) requires node >=23

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -9,6 +9,8 @@ src/content/docs/components/
 src/content/docs/cli/
 src/content/docs/fundamentals/
 src/content/docs/contributing/
+src/content/docs/screenplay/
+src/content/docs/prompter/
 # generated API reference + Storybook (built into public/ by CI or `npm run build:storybook` / `build:api`)
 public/storybook/
 public/storybook-arc/

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -96,10 +96,12 @@ const overviewTopic = {
                 { label: 'AI-native development', slug: 'ai-native-development' },
                 { label: 'Plugins', slug: 'plugins' },
                 { label: 'Code analysis', slug: 'code-analysis' },
+                { label: 'Prompter — docs assistant', link: '/prompter/' },
             ],
         },
         { label: 'Studio', slug: 'studio', badge: { text: 'Soon', variant: 'tip' } },
         { label: 'Event Modeling', slug: 'event-modeling' },
+        { label: 'Screenplay', link: '/screenplay/' },
         {
             label: 'Testing',
             collapsed: true,
@@ -210,7 +212,7 @@ export default defineConfig({
                 shiki: {
                     langAlias: {
                         env: 'ini', pdl: 'text', ebnf: 'text', pql: 'text',
-                        gitignore: 'text', flow: 'text',
+                        gitignore: 'text', flow: 'text', screenplay: 'text',
                     },
                 },
             },
@@ -239,6 +241,8 @@ export default defineConfig({
                         fundamentals: ['/fundamentals', '/fundamentals/**'],
                         contributing: ['/contributing', '/contributing/**'],
                         architecture: ['/architecture', '/architecture/**'],
+                        screenplay: ['/screenplay', '/screenplay/**'],
+                        prompter: ['/prompter', '/prompter/**'],
                     },
                 }),
                 // Per-page action row: Copy Markdown + Open in AI assistant + Share.

--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -98,6 +98,25 @@ const PRODUCTS = [
         ],
     },
     {
+        // Screenplay — the modeling language. A single declarative `.play` file describes
+        // a whole bounded context; Stage runs it live and Studio visualizes the same model.
+        // Content lives in the `screenplay/` subfolder, so point straight at it for clean
+        // `/screenplay/<page>` URLs (the outer Documentation/ wrapper isn't a site page).
+        key: 'screenplay', label: 'Screenplay', icon: 'pencil', sidebarMode: 'toc',
+        src: firstExisting(
+            path.join(reposRoot, 'Screenplay', 'Documentation', 'screenplay'),
+            path.join(docRepoRoot, 'Screenplay', 'Documentation', 'screenplay')),
+        buckets: [
+            { label: 'Start here', sections: ['Getting started'] },
+            { label: 'Understand', sections: ['Why Screenplay', 'Language overview', 'Concepts', 'Policies', 'Modules, features and slices'] },
+            {
+                label: 'Language constructs',
+                sections: ['Events', 'Commands', 'Queries', 'Projections', 'Captures', 'Constraints', 'Reactors', 'Screens'],
+            },
+            { label: 'Reference', sections: ['Sub-language pluggability', 'Grammar', 'Glossary', 'Frequently asked questions'] },
+        ],
+    },
+    {
         // The Cratis CLI — a terminal window into a running Chronicle event store.
         key: 'cli', label: 'CLI', icon: 'rocket', sidebarMode: 'toc',
         src: firstExisting(
@@ -133,6 +152,16 @@ const PRODUCTS = [
         buckets: [
             { label: 'Code Analysis', sections: ['Documentation'] },
         ],
+    },
+    {
+        // Prompter — the community's Discord documentation assistant (RAG bot). Not a stack
+        // layer you build with; it lives on Discord and answers, with citations, grounded in
+        // this very site. Its docs are already Diataxis-shaped (Getting started / Guides /
+        // Concepts / Reference), so no bucket re-grouping is needed.
+        key: 'prompter', label: 'Prompter', icon: 'discord', sidebarMode: 'toc',
+        src: firstExisting(
+            path.join(reposRoot, 'Prompter', 'Documentation'),
+            path.join(docRepoRoot, 'Prompter', 'Documentation')),
     },
 ];
 

--- a/web/src/components/RotatingHero.astro
+++ b/web/src/components/RotatingHero.astro
@@ -1,7 +1,7 @@
 ---
 // Progressive enhancement for the splash hero: rotates the headline, tagline,
-// and actions through four messages (Event Sourcing, CQRS, Application
-// Framework, Studio) with labeled dot indicators. The static hero authored in
+// and actions through the platform's stories (Event Sourcing, CQRS, Application
+// Framework, the Stack, Studio, Screenplay) with labeled dot indicators. The static hero authored in
 // the page frontmatter IS the first pane — without JavaScript nothing here
 // renders and the page degrades to that single message. With JavaScript the
 // script below moves the dot nav into the hero and swaps the hero copy in
@@ -86,6 +86,18 @@ const panes: Pane[] = [
         actions: [
             getStarted,
             { text: 'Learn more', link: '/studio/', variant: 'minimal', icon: 'open-book' },
+            gitHub,
+            community,
+        ],
+    },
+    {
+        label: 'Screenplay',
+        title: 'Write a whole bounded context as one script',
+        tagline:
+            'Screenplay is the Cratis modeling language: describe the events, commands, queries, projections, screens, and rules of a bounded context in a single declarative .play file. Stage runs it as a live application, Studio visualizes the same model, and the C# it generates is the code you ship.',
+        actions: [
+            getStarted,
+            { text: 'Learn more', link: '/screenplay/', variant: 'minimal', icon: 'open-book' },
             gitHub,
             community,
         ],

--- a/web/src/content/docs/ai-native-development.mdx
+++ b/web/src/content/docs/ai-native-development.mdx
@@ -32,7 +32,7 @@ Because the skills encode the conventions, an agent that uses them produces slic
 → See [Plugins](/plugins/) for the full catalog of agents, skills, and coding rules — and how Claude Code and GitHub Copilot load them. The same conventions are enforced during the build by the [code-analysis gates](/code-analysis/).
 
 <Aside type="tip" title="Model first, then generate">
-Pair this with [Studio](/studio/): model the feature on the canvas, generate the C# shapes, then let an agent flesh out the slices around them. Design → generate → build, with AI at each step.
+Pair this with [Studio](/studio/) or [Screenplay](/screenplay/): model the feature on the canvas or as a declarative `.play` script, generate the C# shapes, then let an agent flesh out the slices around them. Design → generate → build, with AI at each step.
 </Aside>
 
 ## Operate with AI: teach your assistant your store

--- a/web/src/content/docs/community.mdx
+++ b/web/src/content/docs/community.mdx
@@ -7,10 +7,11 @@ import { CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
 
 You do not need to be a customer, a contributor, or an event-sourcing expert to ask for help. Cratis is an open community, and we are glad to help people who are evaluating the stack, building their first slice, debugging a running store, or trying to understand the model.
 
-The fastest place to start a conversation is the [Cratis Discord community](https://discord.gg/kt4AMpV8WV). Bring the question you have, even if it is not polished yet.
+The fastest place to start a conversation is the [Cratis Discord community](https://discord.gg/kt4AMpV8WV). Bring the question you have, even if it is not polished yet. There, [Prompter](/prompter/) — the community's documentation assistant — takes the first swing automatically, answering from these docs with citations, or handing you to a human when the docs do not cover it.
 
 <CardGrid>
   <LinkCard title="Join the Cratis Discord" description="Ask questions, talk through designs, get help choosing a path, and meet the people building and using Cratis." href="https://discord.gg/kt4AMpV8WV" />
+  <LinkCard title="Ask Prompter" description="The community's docs assistant on Discord — @mention it, use /ask, or open a help-forum thread and it answers grounded in these docs, with citations, in seconds." href="/prompter/" />
   <LinkCard title="Share feedback" description="Tell us what is confusing, missing, rough, or worth improving in the products and docs." href="/feedback/" />
   <LinkCard title="Get professional help" description="Use dedicated help for private context, workshops, architecture review, implementation, or training." href="/professional-help/" />
   <LinkCard title="Report security privately" description="Use the security page for vulnerability reports and responsible disclosure." href="/security/" />
@@ -22,6 +23,7 @@ The fastest place to start a conversation is the [Cratis Discord community](http
 
 | When you need... | Start with... |
 |---|---|
+| A grounded, cited answer to a docs question in seconds | [Prompter on Discord](/prompter/) |
 | Help deciding whether Cratis fits your system | [Cratis Discord](https://discord.gg/kt4AMpV8WV) |
 | A second pair of eyes on an event model, projection, command, or slice | [Cratis Discord](https://discord.gg/kt4AMpV8WV) |
 | Help with a tutorial, sample, local setup, or first application | [Cratis Discord](https://discord.gg/kt4AMpV8WV) |

--- a/web/src/content/docs/cratis-stack.mdx
+++ b/web/src/content/docs/cratis-stack.mdx
@@ -16,7 +16,7 @@ Most stacks are a bag of libraries you bolt together and then spend the whole pr
 
 Each product is strong on its own — you can [use them separately](/why-cratis/). The reason to reach for the *whole* stack is that the seams disappear: CQRS shapes information going in and out, event sourcing keeps the facts underneath, and everywhere you'd normally hand-write glue, Cratis generates it.
 
-- You **model** the domain, and with access to [Studio](/studio/) that model is how you manage the entire lifecycle of the project — from generated C# to the running system.
+- You **model** the domain — visually on the [Studio](/studio/) canvas, or as a declarative `.play` script in [Screenplay](/screenplay/) — and that one model is how you manage the entire lifecycle of the project, from generated C# to the running system.
 - You **secure the edge**, and [AuthProxy](/authproxy/) authenticates, resolves the tenant, enriches identity, and routes requests.
 - You **write a command**, and [Arc](/arc/) generates the [typed TypeScript proxy](/arc/understanding-the-proxy-boundary/) for it.
 - You **append an event**, and [Chronicle](/chronicle/) accepts it through a gRPC/protobuf boundary, stores it in MongoDB, PostgreSQL, Microsoft SQL Server, or SQLite, and projects the read model from it.
@@ -109,11 +109,16 @@ Cratis ships first-class tooling so an AI agent can build *and* operate the stac
 
 Model in Studio, generate the slices, build them, inspect the result — an agent can take part at every step. [AI-native development](/ai-native-development/) covers the setup and exactly what an agent can do.
 
+And when you or a teammate gets stuck, [Prompter](/prompter/) — the community's Discord assistant — answers Cratis questions grounded in this same documentation, with citations, right where your team already talks.
+
 ## Each layer, on its own and together
 
 <CardGrid>
   <SimpleCard title="Studio — design" icon="open-book" link="/studio/">
     Model the domain on a collaborative event-modeling canvas and generate type-safe C# from it. *(Coming soon.)*
+  </SimpleCard>
+  <SimpleCard title="Screenplay — model as code" icon="pencil" link="/screenplay/">
+    The modeling language: a whole bounded context — events, commands, queries, projections, screens, and rules — in one declarative `.play` file that Stage runs live and Studio visualizes.
   </SimpleCard>
   <SimpleCard title="Chronicle — events" icon="seti:db" link="/chronicle/">
     The event-sourcing engine: gRPC/protobuf boundary, .NET-first client, TypeScript and Elixir clients/contracts, MongoDB/PostgreSQL/SQL Server/SQLite storage, Orleans inside.

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -33,9 +33,9 @@ import SimpleCard from '../../components/SimpleCard.astro';
 import StackJourney from '../../components/StackJourney.astro';
 import RotatingHero from '../../components/RotatingHero.astro';
 
-{/* Rotates the hero above through Event Sourcing / CQRS / Application
-    Framework / Studio messages. The frontmatter hero is the first pane and
-    the no-JS fallback — keep the two in sync. */}
+{/* Rotates the hero above through the platform's stories (Event Sourcing, CQRS,
+    Application Framework, the Stack, Studio, Screenplay). The frontmatter hero is
+    the first pane and the no-JS fallback — keep the two in sync. */}
 <RotatingHero />
 
 ## Get started in 3 steps
@@ -161,6 +161,9 @@ const [authors] = AllAuthors.use();           // typed result, no API client to 
   <SimpleCard title="Components" icon="laptop" link="/components/">
     The React component library — command dialogs, forms, and data tables wired to your proxies.
   </SimpleCard>
+  <SimpleCard title="Screenplay" icon="pencil" link="/screenplay/">
+    The modeling language — describe a whole bounded context in one declarative `.play` file that Stage runs live and Studio visualizes.
+  </SimpleCard>
   <SimpleCard title="AuthProxy" icon="seti:lock" link="/authproxy/">
     The edge gateway — authentication, tenant resolution, identity enrichment, routing, and invites.
   </SimpleCard>
@@ -183,6 +186,7 @@ Cratis is modular. For a new information system, the default path is Chronicle +
 | MongoDB, PostgreSQL, SQL Server, or SQLite storage | [Chronicle storage](/chronicle/hosting/configuration/storage/) |
 | Typed commands, queries, and generated React proxies | [Arc](/arc/) |
 | Forms, dialogs, and data tables wired to Arc | [Components](/components/) |
+| To model a whole bounded context as one declarative file | [Screenplay](/screenplay/) |
 | Authentication, tenant resolution, identity enrichment, and routing | [AuthProxy](/authproxy/) |
 | A way to inspect a running store | [CLI](/cli/) |
 | AI guidance for building and operating the stack | [AI-native development](/ai-native-development/) |
@@ -191,6 +195,7 @@ Cratis is modular. For a new information system, the default path is Chronicle +
 | Runtime, package, and storage compatibility | [Version compatibility](/compatibility/) |
 | A production deployment checklist | [Production readiness](/production-readiness/) |
 | Help choosing a path, debugging setup, or talking through a design | [Community and help](/community/) |
+| Grounded, cited answers to Cratis questions on Discord | [Prompter](/prompter/) |
 | Dedicated training, architecture review, or implementation help | [Professional help](/professional-help/) |
 | A place to suggest improvements or report confusing docs | [Feedback and suggestions](/feedback/) |
 
@@ -206,5 +211,6 @@ Coming from a familiar architecture? Start with the bridge that matches the shap
   <LinkCard title="Follow a learning path" description="Choose a route for event sourcing, full-stack building, evaluation, operations, frontend work, or contribution." href="/learning-paths/" />
   <LinkCard title="Read the FAQ" description="Quick answers for adoption, production readiness, product boundaries, and support channels." href="/faq/" />
   <LinkCard title="Ask the community" description="Join Discord for questions, design discussion, setup help, and guidance on which GitHub repository owns an issue." href="/community/" />
+  <LinkCard title="Ask Prompter on Discord" description="The community's docs assistant answers Cratis questions in seconds, grounded in this site and with citations — or says honestly when the docs don't cover it." href="/prompter/" />
   <LinkCard title="Share feedback" description="Tell us what is confusing, missing, rough, or worth improving in Cratis and the docs." href="/feedback/" />
 </CardGrid>


### PR DESCRIPTION
Wires the **Screenplay** and **Prompter** products into the cratis.io Starlight site and surfaces them across the landing pages.

### Added
- **Screenplay** and **Prompter** as product topics in the sidebar switcher (`sync-content.mjs`): Screenplay from `Documentation/screenplay/` with Diátaxis buckets (Start here / Understand / Language constructs / Reference); Prompter from its already-Diátaxis-shaped toc.
- `astro.config.mjs`: route/topic globs for both, a `screenplay` code-fence alias (so `.play` snippets don't warn), a manual Screenplay link in the overview nav, and Prompter in the AI group.
- `docs-site.yml`: checkout steps for `Cratis/Screenplay` and `Cratis/Prompter` (both public, `main`).
- A Screenplay pane in the rotating hero; cards and starting-point rows on the front door and Cratis Stack; Prompter framed as the community's documentation assistant on the community and AI-native pages.

### Changed
- `.gitignore`: ignore the generated `screenplay/` and `prompter/` content dirs.

Companion PR: Cratis/Screenplay#1 (the Screenplay docs themselves) — merge that first so this build checks out the flat `screenplay/` docs.

Verified locally: full site build is green (all Screenplay pages render — hero, Mermaid, tables, code), and the internal link check reports zero broken links introduced by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)