### PR TITLE
Add Chronicle MCP server to the docs site under AI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "Chronicle.TypeScript"]
 	path = Chronicle.TypeScript
 	url = https://github.com/Cratis/Chronicle.TypeScript
+[submodule "Chronicle.Mcp"]
+	path = Chronicle.Mcp
+	url = https://github.com/Cratis/Chronicle.Mcp

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -4,6 +4,7 @@ dist/
 .astro/
 # generated docs content (synced from product repos by scripts/sync-content.mjs)
 src/content/docs/chronicle/
+src/content/docs/chronicle-mcp/
 src/content/docs/arc/
 src/content/docs/components/
 src/content/docs/cli/

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -96,6 +96,7 @@ const overviewTopic = {
                 { label: 'AI-native development', slug: 'ai-native-development' },
                 { label: 'Plugins', slug: 'plugins' },
                 { label: 'Code analysis', slug: 'code-analysis' },
+                { label: 'Chronicle MCP server', link: '/chronicle-mcp/' },
                 { label: 'Prompter — docs assistant', link: '/prompter/' },
             ],
         },

--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -130,6 +130,19 @@ const PRODUCTS = [
         ],
     },
     {
+        // The Chronicle MCP server — connects an AI agent to a running store over the Model Context
+        // Protocol, for both operating the store and design-time, schema-grounded artifact generation.
+        key: 'chronicle-mcp', label: 'Chronicle MCP', icon: 'node', sidebarMode: 'toc',
+        src: firstExisting(
+            path.join(reposRoot, 'Chronicle.Mcp', 'Documentation'),
+            path.join(docRepoRoot, 'Chronicle.Mcp', 'Documentation')),
+        buckets: [
+            { label: 'Start here', sections: ['Getting started', 'Configuration'] },
+            { label: 'Understand', sections: ['How it works'] },
+            { label: 'Capabilities', sections: ['Operate-side', 'Design-time'] },
+        ],
+    },
+    {
         // Shared utilities (concepts, serialization, DI, type discovery) for .NET and TS.
         key: 'fundamentals', label: 'Fundamentals', icon: 'seti:folder', sidebarMode: 'toc',
         src: firstExisting(


### PR DESCRIPTION
Adds the Chronicle MCP server documentation to the aggregated docs site, the same way every other product is included — as a submodule wired into the navigation.

## Added

- Chronicle.Mcp as a git submodule, so its `Documentation/` folder is aggregated into the site.
- A **Chronicle MCP** product topic (getting started, configuration, how it works, and the operate-side and design-time capability pages), registered in the content sync with Diátaxis buckets.
- A **Chronicle MCP server** entry under the **AI** group of the Cratis Stack navigation, alongside Prompter.