### PR TITLE
Check out Chronicle.Mcp in the docs-site build

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -83,6 +83,14 @@ jobs:
           token: ${{ secrets.DOCS_CHECKOUT_TOKEN || github.token }}
           path: Chronicle.TypeScript
 
+      - name: Checkout Chronicle.Mcp
+        uses: actions/checkout@v4
+        with:
+          repository: Cratis/Chronicle.Mcp
+          ref: main
+          token: ${{ secrets.DOCS_CHECKOUT_TOKEN || github.token }}
+          path: Chronicle.Mcp
+
       - name: Checkout Arc
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Fixed

- The Chronicle MCP product topic had no checkout step in the docs-site workflow, so its documentation source was missing in CI — the `/chronicle-mcp/` pages never rendered and the AI-group navigation link to them broke on every page. Add the `Chronicle.Mcp` checkout step, matching every other product, so the pages build and the links resolve.